### PR TITLE
Filepath getter doesn't erase custom paths anymore

### DIFF
--- a/thesdk/iofile.py
+++ b/thesdk/iofile.py
@@ -77,6 +77,7 @@ class iofile(IO):
              self.hasheader=kwargs.get('hasheader',False) # Headers False by default. 
                                                           # Do not generate things just 
                                                           # to remove them in the next step
+
              if hasattr(self.parent,'preserve_iofiles'):
                  self.preserve=parent.preserve_iofiles
              else:
@@ -177,8 +178,9 @@ class iofile(IO):
          ''' Name of the IO file to be read or written.
 
          '''
-         self._file=self.parent.simpath +'/' + self.name \
-                 + '_' + self.rndpart +'.txt'
+         if not hasattr(self,'_file'):
+             self._file=self.parent.simpath +'/' + self.name \
+                     + '_' + self.rndpart +'.txt'
          return self._file
      @file.setter
      def file(self,val):


### PR DESCRIPTION
Modified self.file property, before it was forcing a pre-defined
temporary file path even if it was set manually. Now it is possible to
back-up simulation results even from python simulations using e.g.
rtl_iofile class as textIO engine