### PR TITLE
Add par and queue properties

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -371,6 +371,37 @@ class thesdk(metaclass=abc.ABCMeta):
             return retval
         return wrapper_timer
 
+    @property
+    def par(self):  
+        """True | False (default)
+
+        Property defines whether parallel run is intended or not"""
+
+        if hasattr(self,'_par'):
+            return self._par
+        else:
+            self._par=False
+        return self._par
+
+    @par.setter
+    def par(self,value):
+        self._par = value
+
+    @property
+    def queue(self):  
+        """Property holding the queue for parallel run result
+        
+        """
+
+        if hasattr(self,'_queue'):
+            return self._queue
+        else:
+            self._queue = []
+        return self._queue
+
+    @queue.setter
+    def queue(self,value):
+        self._queue = value
 
     def run_parallel(self, **kwargs):
         """ 
@@ -378,7 +409,6 @@ class thesdk(metaclass=abc.ABCMeta):
 
             self.par= True
             self.queue= []
-            self.return_IOS= True/False # Decides if IOS are updated for after running each instance
 
         The method you call (for example run), needs to have::
 
@@ -399,8 +429,8 @@ class thesdk(metaclass=abc.ABCMeta):
         Parameters
         ----------
          **kwargs:  
-                 duts: (??)
-                    Set of instances 
+                 duts: list
+                    List of instances 
                  method: str
                      Method called for each object (default: run)
         """
@@ -425,7 +455,7 @@ class thesdk(metaclass=abc.ABCMeta):
                 elif hasattr(i,key):
                     setattr(i,key,value)
                 else:
-                    self.print_log(type='W', msg='Reult data from parallel run of %s saved to new attribute \'%s\'' %(i, key))
+                    self.print_log(type='W', msg='Result data from parallel run of %s saved to new attribute \'%s\'' %(i, key))
                     setattr(i,key,value)
             proc[n].join()
             n+=1

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -366,36 +366,39 @@ class thesdk(metaclass=abc.ABCMeta):
 
 
     def run_parallel(self, **kwargs):
-        """ 
-        Parameters you need to set for instances you want to run in parallel::
+        """ Run instances in parallel and collect results
+
+        Usage: Takes in a set of instances, runs a given method for them, and saves result data to the original instances
+
+        Parameters you need in the instances::
 
             self.par= True
             self.queue= []
-            self.return_IOS= True/False # Decides if IOS are updated for after running each instance
 
-        The method you call (for example run), needs to have::
+        In order to pass the return que from the parent, the method you call (for example run), needs to have::
 
             def run(self,*arg):
                 if len(arg)>0:
                     self.par=True      #flag for parallel processing
                     self.queue=arg[0]  #multiprocessing.queue as the first argument
 
-        To get data out place this at the end of your method. ::
+        Results are returned as a dictionary. The dictionary can include IOS, which are saved to IOS of the original instance. 
+        Otherwise non-IO key-value pairs are saved as attributes for the original instance.
+        This is an example of returning both IOS and other data (place at the end of your simlation)::
 
             if self.par==True: 
-                retlist = self.IOSdict_for_parent() # returns a dictionary in a list (if return_IOS is false, the dict is empty). Currently required even if return_IOS = False
-                customret = {'amplitude' : self.sig_sco.peak_to_peak} #optional. Example for returning data other than IOS. These key value pairs end up as parameters for the ran instance
-                retlist.append(customret) #optional (see above)
-                self.queue.put(retlist)
+                ret_dict = {'NF' : 25} 
+                ret_dict.update(self.IOS.Members) #Adds IOS to return dictionary
+                self.queue.put(ret_dict)
 
         ----------
         Parameters
         ----------
          **kwargs:  
-                 duts: (??)
-                    Set of instances 
+                 duts: list of objects
+                    Set of instances you want to simulate
                  method: str
-                     Method called for each object (default: run)
+                     Method called for each instance (default: run)
         """
 
         duts=kwargs.get('duts') 
@@ -418,7 +421,7 @@ class thesdk(metaclass=abc.ABCMeta):
                 elif hasattr(i,key):
                     setattr(i,key,value)
                 else:
-                    self.print_log(type='W', msg='Reult data from parallel run of %s saved to new attribute \'%s\'' %(i, key))
+                    self.print_log(type='W', msg='Result data from parallel run of %s saved to a new attribute \'%s\'' %(i, key))
                     setattr(i,key,value)
             proc[n].join()
             n+=1


### PR DESCRIPTION
@kspoof Try this and merge. These should remove the need for defining these in Entities.

PS. Check if the instructions to run_parallel are up to date. I think those are still according to previous construct.