### PR TITLE
Add IOS and extract properties

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -445,7 +445,7 @@ class thesdk(metaclass=abc.ABCMeta):
         n=0
         for i in duts:
             que.append(multiprocessing.Queue())
-            proc.append(multiprocessing.Process(target=getattr(i,method) ,args=(que[n],)))
+            proc.append(multiprocessing.Process(target=getattr(i,method)))
             i.par = True
             i.queue = que[n]
             proc[n].start()

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -454,10 +454,52 @@ class thesdk(metaclass=abc.ABCMeta):
                 elif hasattr(i,key):
                     setattr(i,key,value)
                 else:
-                    self.print_log(type='W', msg='Result data from parallel run of %s saved to new attribute \'%s\'' %(i, key))
-                    setattr(i,key,value)
+                    i.extracts.Members[key] = value
             proc[n].join()
             n+=1
+
+    @property
+    def IOS(self):  
+        """ Type: Bundle of IO's
+        
+        Property holding the IOS
+
+        Example:
+            self.IOS.Members['input_A']=IO()
+        
+        """
+
+        if hasattr(self,'_IOS'):
+            return self._IOS
+        else:
+            self._IOS = Bundle()
+        return self._IOS
+
+    @IOS.setter
+    def IOS(self,value):
+        self._IOS = value
+
+    @property
+    def extracts(self):  
+        """ Type: Bundle 
+        
+        Bundle for holding the returned results from simulations that are not
+        attributes or IO's
+
+        Example:
+            self.IOS.Members['input_A']=IO()
+        
+        """
+
+        if hasattr(self,'_extracts'):
+            return self._extracts
+        else:
+            self._extracts = Bundle()
+        return self._extracts
+
+    @extracts.setter
+    def IOS(self,value):
+        self._IOS = value
 
 class IO(thesdk):
     ''' TheSyDeKick IO class. Child of thesdk to utilize logging method.


### PR DESCRIPTION
Add IOS property removing requirement for defining it in Entity

Add extracts property. Parallel run dumps the results with no
pre-defined attributes or IO's as members of this Bundle.

Modify parallel_run accordingly