### PR TITLE
Support for splitting parallel tasks to smaller chunks

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -506,6 +506,8 @@ class thesdk(metaclass=abc.ABCMeta):
         nbatch = int(np.ceil(len(duts)/max_jobs))
         for j in range(nbatch):
             dutrange = range(j*max_jobs,(j+1)*max_jobs)
+            if dutrange.stop > len(duts):
+                dutrange = range(j*max_jobs,len(duts))
             que=[]
             proc=[]
             for i in dutrange:


### PR DESCRIPTION
Added 'num_jobs' argument to run_parallel for splitting parallel tasks
into smaller chunks. The function now tries to run at most 'num_jobs'
tasks at a time, before submitting new ones.


There seems to be bug with this. I have to sort it out before review & merge.