### PR TITLE
Flush write cache instead of waiting

### DIFF
--- a/thesdk/iofile.py
+++ b/thesdk/iofile.py
@@ -290,8 +290,9 @@ class iofile(IO):
                  df.to_csv(path_or_buf=self.file,sep="\t",index=False,header=header_line)
              else:
                  df.to_csv(path_or_buf=self.file,sep="\t",index=False,header=False)
-         # This is to compensate filesystem delays
-         time.sleep(10)
+         # Flush cached file system writes
+         with open(self.file) as fd:
+             os.fsync(fd)
          
      # Reading
      def read(self,**kwargs):


### PR DESCRIPTION
Explicitly flush the write cache instead of waiting for ten seconds. I'm not aware of the initial "filesystem delays" that prompted the addition of the delay, but this patch has sped up my workflow considerably (especially when working with multiple IO files) and I haven't encountered any errors in use after starting to use it.

@mkosunen can you test this against the workloads where you have experienced those filesystem delays.