### PR TITLE
Proposal for speeding up appending SDK modules to PATH

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -89,11 +89,17 @@ class thesdk(metaclass=abc.ABCMeta):
     #This variable becomes redundant after the GLOBALS dictionary is created
     global_parameters=['LSFSUBMISSION','LSFINTERACTIVE','ELDOLIBFILE','SPECTRELIBFILE']
 
-    #Appending all TheSDK python modules to system path (only once, with set subtraction)
-    #This could be done as oneliner with lambda,filter, map and recude, but due to name scope 
-    #definitions, this is simpler method in class definition
-    MODULEPATHS=[os.path.split(os.path.split(y)[0])[0] for y in [ filename for filename in 
-        glob.iglob( HOME+'/Entities/**/__init__.py',recursive=True)]] 
+    # Append all SDK python modules to path. Strategy: 
+    # 1. iterate over paths starting from Entities directory
+    # 2.1 if Entities/<path> is not a file, check if Entities/<path>/<path>/__init__.py exists
+    # 3. If it does, it is a SDK module -> add to path
+
+    MODULEPATHS=[]
+    root = os.path.join(HOME, 'Entities')
+    for item in os.listdir(root):
+        if not os.path.isfile(os.path.join(root, item)):
+            if os.path.isfile(os.path.join(root, item, item, '__init__.py')):
+                MODULEPATHS.append(os.path.join(root, item))
     for i in list(set(MODULEPATHS)-set(sys.path)):
         if 'BagModules' not in i:
             print("Adding %s to system path" %(i))


### PR DESCRIPTION
It seems that running any SDK module hangs the execution when modules are added to path. The problem seems to be that we loop over all of the directories recursively that are found under Entities. This is a poor startegy, since entities may contain multiple directories and hence slow down the process.

This pull request aims to solve the problem by relying on the fact that the modules follow fixed convention:
1. The module is always located under Entities/<module_name>/<module_name>/__init__.py
2. If there exists a directory called <module_name> under Entities, and this directory contains sub-directory <module_name>, within which __init__.py is located, we can add Entities/<module_name> to path.

By relying on the fixed structure, we don't need to loop over all of the directories, hence speeding up the process. One additional comment: we could parse the path based on the init_submodules.sh file. This file lists all of the modules that are present in the project. We could print a warning if the module is found under Entities but not defined in init_submodules.sh. This would enforce adding the modules to init_submodules.sh, which I actively forget to do :) 

 Tested with inverter module, works fine. 