### PR TITLE
Add exception catcher for empty iofile

### DIFF
--- a/thesdk/iofile.py
+++ b/thesdk/iofile.py
@@ -333,6 +333,7 @@ class iofile(IO):
                 self.Data=readd.values
          except pd.errors.EmptyDataError:
             # File was empty
+            self.print_log(type="W", msg="IOFile was empty! %s" %(self.file))
             self.Data = None
          fid.close()
  

--- a/thesdk/iofile.py
+++ b/thesdk/iofile.py
@@ -313,23 +313,27 @@ class iofile(IO):
          fid=open(self.file,'r')
          self.datatype=kwargs.get('datatype',self.datatype)
          dtype=kwargs.get('dtype',object)
-         readd = pd.read_csv(fid,dtype=dtype,sep='\t',header=None)
-         #read method for complex signal matrix
-         if self.datatype is 'complex' or self.datatype is 'scomplex':
-             self.print_log(type="I", msg="Reading complex")
-             rows=int(readd.values.shape[0])
-             cols=int(readd.values.shape[1]/2)
-             for i in range(cols):
-                 if i==0:
-                     self.Data=np.zeros((rows, cols),dtype=complex)
-                     self.Data[:,i]=readd.values[:,2*i].astype('int')\
-                             +1j*readd.values[:,2*i+1].astype('int')
-                 else:
-                     self.Data[:,i]=readd.values[:,2*i].astype('int')\
-                             +1j*readd.values[:,2*i+1].astype('int')
- 
-         else:
-             self.Data=readd.values
+         try:
+            readd = pd.read_csv(fid,dtype=dtype,sep='\t',header=None)
+            #read method for complex signal matrix
+            if self.datatype is 'complex' or self.datatype is 'scomplex':
+                self.print_log(type="I", msg="Reading complex")
+                rows=int(readd.values.shape[0])
+                cols=int(readd.values.shape[1]/2)
+                for i in range(cols):
+                    if i==0:
+                        self.Data=np.zeros((rows, cols),dtype=complex)
+                        self.Data[:,i]=readd.values[:,2*i].astype('int')\
+                                +1j*readd.values[:,2*i+1].astype('int')
+                    else:
+                        self.Data[:,i]=readd.values[:,2*i].astype('int')\
+                                +1j*readd.values[:,2*i+1].astype('int')
+    
+            else:
+                self.Data=readd.values
+         except pd.errors.EmptyDataError:
+            # File was empty
+            self.Data = None
          fid.close()
  
      # Remove the file when no longer needed


### PR DESCRIPTION
In the current flow, if an output IOFile is empty, the flow throws an error at `pd.read_csv` (line 316, `iofile.py`). I think it should be allowed to generate an empty IOFile. This can happen, if you have specified a manual `io_condition` that has not been fulfilled during the simulation. (like `mstopsim` in ACore Tests)

This PR adds an exception catcher and assignes `None` to the datatype, if the file is empty.