### PR TITLE
Add `VLOGLIBFILE` to `global_parameters`

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -87,7 +87,7 @@ class thesdk(metaclass=abc.ABCMeta):
     print("Config file of TheSDK is %s" %(CONFIGFILE))
 
     #This variable becomes redundant after the GLOBALS dictionary is created
-    global_parameters=['LSFSUBMISSION','LSFINTERACTIVE','ELDOLIBFILE','SPECTRELIBFILE']
+    global_parameters=['LSFSUBMISSION','LSFINTERACTIVE','ELDOLIBFILE','SPECTRELIBFILE','VLOGLIBFILE']
 
     # Append all SDK python modules to path. Strategy: 
     # 1. iterate over paths starting from Entities directory


### PR DESCRIPTION
Adds the key `VLOGLIBFILE` to `global_parameters` so that it can be used to point to a file containing process dependent verilog simulation models.