### PR TITLE
Fix loading results causing empty directories to be created

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -224,7 +224,12 @@ class thesdk(metaclass=abc.ABCMeta):
         This is not meant to be set manually.
         """
         #This property is dependent, it should not be fixed in creation
-        name = self.runname if self.runname != '' else self.load_state
+        if hasattr(self, '_runname'):
+            name = self.runname
+        elif hasattr(self, '_load_state'):
+            name = self._load_state
+        else:
+            self.print_log(type='F', msg='Entity runname or load_state not set! This shouldn\'t happen!')
         self._simpath = '%s/simulations/%s/%s' % (self.entitypath,self.model,name)
         try:
             if not (os.path.exists(self._simpath)):


### PR DESCRIPTION
@sporrasm "Apparently this was caused by checking if self.runname is equal to empty string. This condition will always be false, since accessing self.runname creates a random string, if not already set. The correct way is to check if the attribute exists in the first place."

The comment above the line you removed says: "This is dependent, it can not be fixed in creation" . Therefore your fix can not be implemented.



