### PR TITLE
Add simpathroot property

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -234,7 +234,7 @@ class thesdk(metaclass=abc.ABCMeta):
         Default self.entitypath
         """
         if not hasattr(self,'_simpathroot'):
-            self._simpathroot=sefl.entitypath
+            self._simpathroot=self.entitypath
         return self._simpathroot
 
     @simpathroot.setter

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -247,7 +247,8 @@ class thesdk(metaclass=abc.ABCMeta):
         """String
 
         Simulation path. (./simulations/<model>/<runname>)
-        This is not meant to be set manually.
+        This is not meant to be set manually. Use 'simpathroot'
+        to relocate.
         """
         #This property is dependent, it should not be fixed in creation
         name = self.runname if self.runname != '' else self.load_state
@@ -261,7 +262,7 @@ class thesdk(metaclass=abc.ABCMeta):
         return self._simpath
     @simpath.setter
     def simpath(self,val):
-        self._simpath=val
+        self.print_log(type='F', msg="Setting simpath has no effect. Set 'simpathroot' instead.")
         return self._simpath
    
     @property 

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -225,6 +225,22 @@ class thesdk(metaclass=abc.ABCMeta):
             self.print_log(type='E', msg= 'Simulator model %s not supported.' %(val))
         self._model=val
         return self._model
+    @property
+    def simpathroot(self):
+        """String
+
+        Simulation path root.
+
+        Default self.entitypath
+        """
+        if not hasattr(self,'_simpathroot'):
+            self._simpathroot=sefl.entitypath
+        return self._simpathroot
+
+    @simpathroot.setter
+    def simpathroot(self,val):
+        self._simpathroot=val
+        return self._simpathroot
 
     @property
     def simpath(self):
@@ -235,7 +251,7 @@ class thesdk(metaclass=abc.ABCMeta):
         """
         #This property is dependent, it should not be fixed in creation
         name = self.runname if self.runname != '' else self.load_state
-        self._simpath = '%s/simulations/%s/%s' % (self.entitypath,self.model,name)
+        self._simpath = '%s/simulations/%s/%s' % (self.simpathroot,self.model,name)
         try:
             if not (os.path.exists(self._simpath)):
                 os.makedirs(self._simpath)

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -263,7 +263,6 @@ class thesdk(metaclass=abc.ABCMeta):
     @simpath.setter
     def simpath(self,val):
         self.print_log(type='F', msg="Setting simpath has no effect. Set 'simpathroot' instead.")
-        return self._simpath
    
     @property 
     def has_lsf(self):


### PR DESCRIPTION
Simpath is a dependent property, so it can not be set. Simpath is now set with smpathroot property. It relocates the simulation directories under the given root.