### PR TITLE
When copy_propval sets attribute, print with debug flag

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -346,7 +346,8 @@ class thesdk(metaclass=abc.ABCMeta):
                 if hasattr(self,prop) and hasattr(self.parent, prop):
                     #Its nice to see how things propagate
                     msg="Setting %s: %s to %s" %(self, prop, getattr(self.parent,prop))
-                    self.print_log(type= 'I', msg=msg)
+                    # As nice as it is to see how things propagate, it quickly fill the logfiles with garbage
+                    self.print_log(type= 'D', msg=msg)
                     setattr(self,prop,getattr(self.parent,prop))
                 else:
                     obj = self if not hasattr(self, prop) else self.parent


### PR DESCRIPTION
The logging prints are cluttered with redundant information when instantiating entites with a parent. I propose we move these prints under the DEBUG flag. If the user wants to debug parameter propagation, they should use the DEBUG flag.