### PR TITLE
Add option to supress output

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -356,7 +356,9 @@ class thesdk(metaclass=abc.ABCMeta):
     @property
     def supress_output(self):
         """
-        Optional flag to supress all print_log output to stdout
+        Bool : Optional flag to supress all print_log output to stdout
+
+        Defaul: False
         """
         if not hasattr(self, '_supress_output'):
             self._supress_output=False

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -183,7 +183,7 @@ class thesdk(metaclass=abc.ABCMeta):
 
     @property
     def print_relative_path(self):
-        ''' True (default) | False
+        ''' True (default) | False
 
         If True, print all paths relative to the entity path. If False, paths
         are printed as is (typically absolute paths).
@@ -273,7 +273,7 @@ class thesdk(metaclass=abc.ABCMeta):
    
     @property 
     def has_lsf(self):
-        """True | False (default)
+        """True | False (default)
 
         True if LSFINTERACTIVE and LSFSUBMISSION global veriables are defined
         in TheSDK.config.
@@ -353,6 +353,20 @@ class thesdk(metaclass=abc.ABCMeta):
                     msg = "Property %s not defined for entity %s, omitting copy!" % (prop,obj)
                     self.print_log(type='D',msg=msg)
 
+    @property
+    def supress_output(self):
+        """
+        Optional flag to supress all print_log output to stdout
+        """
+        if not hasattr(self, '_supress_output'):
+            self._supress_output=False
+        return self._supress_output
+
+    @supress_output.setter
+    def supress_output(self, val):
+        self._supress_output=val
+
+
     #Method for logging
     #This is a method because it uses the logfile property
     def print_log(self,**kwargs):
@@ -406,7 +420,8 @@ class thesdk(metaclass=abc.ABCMeta):
         if type == 'D':
             if self.DEBUG:
                 typestr="[DEBUG]"
-                print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cblue,typestr,cend, 
+                if not self.supress_output:
+                    print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cblue,typestr,cend, 
                     self.__class__.__name__ , msg))
                 if hasattr(self,"logfile"):
                     fid= open(thesdk.logfile, 'a')
@@ -416,23 +431,28 @@ class thesdk(metaclass=abc.ABCMeta):
             return
         elif type == 'I':
             typestr ="[INFO]"
-            print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cgreen,typestr,cend, 
+            if not self.supress_output:
+                print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cgreen,typestr,cend, 
                 self.__class__.__name__ , msg))
         elif type =='W':
             typestr = "[WARNING]"
-            print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cyellow,typestr,cend, 
+            if not self.supress_output:
+                print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cyellow,typestr,cend, 
                 self.__class__.__name__ , msg))
         elif type =='E':
             typestr = "[ERROR]"
-            print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cred,typestr,cend, 
+            if not self.supress_output:
+                print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cred,typestr,cend, 
                 self.__class__.__name__ , msg))
         elif type =='O':
             typestr = "[OBSOLETE]"
-            print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cviolet,typestr,cend, 
+            if not self.supress_output:
+                print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cviolet,typestr,cend, 
                 self.__class__.__name__ , msg))
         elif type =='F':
             typestr = "[FATAL]"
-            print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cred,typestr,cend, 
+            if not self.supress_output:
+                print("%s %s%s%s %s: %s" %(time.strftime("%H:%M:%S"),cred,typestr,cend, 
                 self.__class__.__name__ , msg))
             print("Quitting due to fatal error in %s" %(self.__class__.__name__))
             if hasattr(self,"logfile"):
@@ -758,7 +778,7 @@ class thesdk(metaclass=abc.ABCMeta):
 
     @property
     def save_state(self):  
-        """True | False (default)
+        """True | False (default)
         
         Save the entity state after simulation (including output data). Any
         stored state can be loaded using the matching state name passed to the
@@ -803,7 +823,7 @@ class thesdk(metaclass=abc.ABCMeta):
 
     @property
     def load_state_full(self):  
-        """True (default) | False
+        """True (default) | False
         
         Whether to load the full entity state or not. If False, only IOs are
         loaded in order to not override the entity state otherwise. In that


### PR DESCRIPTION
To close the issue about "it's nice to see things propagte" once and for all, I created this. This effectively disables all print_log output from stdout, if the user so chooses. By default, everything is printed, but if the user willingly wants to disable this, they are free to do so.

In my opinion #53 can still be merged, if absolutely desired. I tested it and it works, but this method is more forceful, as it can be used to supress all messages (i.e. "Initalizing <entityname>"), rather than just propagation prints.

