### PR TITLE
Add functionality to track IO connections

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -1254,23 +1254,6 @@ class IO(thesdk):
             io._Data = shared_ref
             shared_ref.connections.add(io)
 
-    @property
-    def data(self):
-        if hasattr(self, "_Data"):
-            return self._Data
-        else:
-            self._Data = None
-
-        self.print_log(
-            type="O",
-            msg="IO attribute 'data' is obsoleted by attribute 'Data' Will be removed in release 1.4",
-        )
-        return self._Data
-
-    @data.setter
-    def data(self, value):
-        self._Data = value
-
     def __getstate__(self):
         return self.__dict__.copy()
 

--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -1191,6 +1191,13 @@ class thesdk(metaclass=abc.ABCMeta):
                     val.remove()
 
 
+class _Data:
+    """Helper class to store shared data and track connected IOs."""
+    def __init__(self, value=None):
+        self.value = value
+        self.connections = set()
+
+
 class IO(thesdk):
     """TheSyDeKick IO class. Child of thesdk to utilize logging method.
 
@@ -1219,20 +1226,33 @@ class IO(thesdk):
 
         """
 
-        self._Data = kwargs.get("Data", None)
+        self._Data = _Data(kwargs.get('Data', None))
+        self._Data.connections.add(self)
 
     @property
     def Data(self):
         """Data value of this IO"""
-        if hasattr(self, "_Data"):
-            return self._Data
-        else:
-            self._Data = None
-        return self._Data
+        return self._Data.value
 
     @Data.setter
     def Data(self, value):
-        self._Data = value
+        self._Data.value = value
+
+    def connect(self, other):
+        """Connect this IO to another IO so they share data."""
+        if not isinstance(other, IO):
+            raise TypeError("Can only connect IO to IO")
+
+        # Merge connection groups: all IOs will share the same _dataref
+        all_ios = self._Data.connections | other._Data.connections
+
+        # Use one of the existing datarefs as the shared one
+        shared_ref = other._Data
+
+        # Update all IOs to point to the shared ref
+        for io in all_ios:
+            io._Data = shared_ref
+            shared_ref.connections.add(io)
 
     @property
     def data(self):

--- a/thesdk/bundle.py
+++ b/thesdk/bundle.py
@@ -2,6 +2,17 @@
 # Class is needed to define bundle operations
 import abc
 from abc import *
+import thesdk
+
+
+class IODict(dict):
+    """Dictionary that automatically connects IOs instead of replacing them."""
+    def __setitem__(self, key, value):
+        # If both sides are IOs, perform connection instead of reassignment
+        if key in self and isinstance(self[key], thesdk.IO) and isinstance(value, thesdk.IO):
+            self[key].connect(value)
+        else:
+            super().__setitem__(key, value)
 
 
 class Bundle(metaclass=abc.ABCMeta):
@@ -26,7 +37,7 @@ class Bundle(metaclass=abc.ABCMeta):
         Members: dict, dict([])
 
         """
-        self.Members = dict([])
+        self.Members = IODict([])
 
     def new(self, **kwargs):
         """Parameters


### PR DESCRIPTION
One thing I noticed when trying to connect different IO classes by reference instead of Data. Lets say you first do this:

```
self.adc.IOS.Members['RFP'] = self.i_genp.IOS.Members['out']
```

Those two will be the same pointers, and when data under it changes, both IOs see the change. Problem arises if you redefine one of the pointers somewhere else, e.g.

```
self.i_genp.IOS.Members['out'] = self.datagen.IOS.Members['out']
```

Now, these two point to the same address, but that address is different to `self.adc.IOS.Members['RFP']`. Therefore, that IO will now point to nothing and remain empty.

The proper way to implement the IO class would be to actually track the instances it is connected to, and update the references. So that, if initally `a = b`, and then later you set `b = c`, then IO class would handle it automatically so that `a = c`

This MR fixes this by 
- specifying a helper class, `_Data`, that contains the value (typically a numpy array) as well as a list of connections. 
- Furthermore, a method `connect()` is defined that is used to "connect" one IO to another by reference. However, usage of this `connect()` function is hidden from the user. 
- In Bundle class, the IO bundle is now defined as a new class called IODict that extends regular dict by adding an assignment overload. 
- When two IOs are assigned to each other, their connection lists are merged. Thus, all IOs that are "connected" to this node, point to the same data reference.

This MR is *fully backwards compatible*, assuming that no one has done anything super duper hacky stuff in their setups.