### PR TITLE
add ngspicelibfile

### DIFF
--- a/thesdk/__init__.py
+++ b/thesdk/__init__.py
@@ -93,6 +93,7 @@ class thesdk(metaclass=abc.ABCMeta):
         "LSFINTERACTIVE",
         "ELDOLIBFILE",
         "SPECTRELIBFILE",
+        "NGSPICELIBFILE",
         "VLOGLIBFILE",
         "VHDLLIBFILE",
     ]


### PR DESCRIPTION
Add NGSPICELIBFILE to global parameters to allow use of ngspice models.